### PR TITLE
Make the build script more idempotent

### DIFF
--- a/build-google-mcp.sh
+++ b/build-google-mcp.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -e
 
-echo "Cloning google_workspace_mcp repository..."
-git clone https://github.com/taylorwilsdon/google_workspace_mcp.git /tmp/google_workspace_mcp
+tempdir=$(mktemp -d)
+echo "Cloning google_workspace_mcp repository into $tempdir..."
+git clone https://github.com/taylorwilsdon/google_workspace_mcp.git $tempdir/google_workspace_mcp
 
-cd /tmp/google_workspace_mcp
+cd $tempdir/google_workspace_mcp
 
 echo "Building podman container..."
 podman build -t google-workspace-mcp .


### PR DESCRIPTION
Previously, the build-google-mcp.sh script would fail if you attempted to run it multiple times as the /tmp/google_workspace_mcp directory would already exist. This change updates the script to create a new temp dir for this repo path, making the script runnable multiple times. The temp dir will automatically be cleaned up to your machine's local policy for deleting temp files.